### PR TITLE
PIPE2D-852: Added a list of broadband fluxes for various SEDs

### DIFF
--- a/fluxCalibration/README.md
+++ b/fluxCalibration/README.md
@@ -1,0 +1,28 @@
+syntheticFlux_withInterp_ps_HSCPS1GaiaSDSS.fits
+-----------------------------------------------
+
+This FITS BinTable includes the synthetic photometry
+of 56456 stellar model templates with four instruments.
+Available filters are:
+
+    HSC g, r, r2, i, i2, z, y,
+    Gaia Bp, Rp, G,
+    PS1 g, r, i, z, y,
+    SDSS u, g, r, i, z.
+
+The stellar model templates are based on the AMBRE templates
+(de Laverny et al. 2012, A&A, 544, 126).
+The original resolutions of the four stellar parameters
+(effective temperature [Teff K], surface gravity [Log(g/cm/s^2)],
+metallicity [M/H], and alpha-elements abundance [alpha/Fe])
+were regrided into small ones
+and the templates were interpolated
+using a radial basis function (`scipy.interpolate.Rbf`).
+This table gives the four stellar parameters
+and the corresponding synthetic photometry set in Janskies.
+Photon-counting detectors were assumed
+in the computation of the synthetic photometries.
+
+This table was computed by T. Yamashita,
+but is due to be generated on the user side.
+A computing script and necessary materials will be provided in future.

--- a/fluxCalibration/syntheticFlux_withInterp_ps_HSCPS1GaiaSDSS.fits
+++ b/fluxCalibration/syntheticFlux_withInterp_ps_HSCPS1GaiaSDSS.fits
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:833e34cb34aa3bb5228a66d6e055efecd95eed121cf76a3f5f24510551e34c56
+size 11301120


### PR DESCRIPTION
This file is required by drp_stella's fitBroadbandSED.py.